### PR TITLE
Add psycopg2 to python dependencies

### DIFF
--- a/ansible/roles/python/tasks/main.yml
+++ b/ansible/roles/python/tasks/main.yml
@@ -13,6 +13,7 @@
 - name: install python dependencies from pip
   pip: name={{ item }} state=present
   with_items:
+    - psycopg2
     - supervisor
     - virtualenv
     - virtualenvwrapper


### PR DESCRIPTION
We need psycopg2 on hosts in order to run the Ansible postgres modules