### PR TITLE
Turn off nginx cache settings.

### DIFF
--- a/ansible/roles/nginx/files/nginx.conf
+++ b/ansible/roles/nginx/files/nginx.conf
@@ -54,9 +54,9 @@ http {
     # Cache Settings
     ##
 
-    expires 30d;
-    add_header Pragma public;
-    add_header Cache-Control "public";
+    # expires 30d;
+    # add_header Pragma public;
+    # add_header Cache-Control "public";
 
     ##
     # Virtual Host Configs


### PR DESCRIPTION
We shouldn't be caching API responses, especially not in nginx.