### PR TITLE
Feature/update get latest AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,7 @@ Builds Ubuntu AMIs using Ansible.
 
         eval $(awsenv packer)
 
- 4. Choose a source AMI (e.g. from [https://cloud-images.ubuntu.com/locator/ec2](), searching
-    for "trusty us-east-1 hvm:ebs-ssd"):
-
-        export AWS_SOURCE_AMI=ami-50759d3d
-    
-    or use our helper script which basically does the same thing:
+ 4. Use our helper script to select the latest offical Ubuntu trusty AMI:
         
         export AWS_SOURCE_AMI=$(./scripts/get_latest_ami_helper.sh)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Builds Ubuntu AMIs using Ansible.
     for "trusty us-east-1 hvm:ebs-ssd"):
 
         export AWS_SOURCE_AMI=ami-50759d3d
+    
+    or use our helper script which basically does the same thing:
+        
+        export AWS_SOURCE_AMI=$(./get_latest_ami_helper.sh)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Builds Ubuntu AMIs using Ansible.
     
     or use our helper script which basically does the same thing:
         
-        export AWS_SOURCE_AMI=$(./get_latest_ami_helper.sh)
+        export AWS_SOURCE_AMI=$(./scripts/get_latest_ami_helper.sh)
 
 ## Usage
 

--- a/scripts/get_latest_ami_helper.sh
+++ b/scripts/get_latest_ami_helper.sh
@@ -12,4 +12,4 @@ OWNER_ID=099720109477
 aws ec2 describe-images \
     --region $REGION \
     --filter Name=owner-id,Values=$OWNER_ID \
-    --query 'Images[? starts_with(ImageLocation, `099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server`)] | sort_by(@, & ImageLocation) | [-1] | ImageId'  --out text
+    --query "Images[? starts_with(ImageLocation, \`$OWNER_ID/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server\`)] | sort_by(@, & ImageLocation) | [-1] | ImageId"  --out text

--- a/scripts/get_latest_ami_helper.sh
+++ b/scripts/get_latest_ami_helper.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+# This script retrieves the latest official Canonical Ubuntu image from 
+# the AWS EC2 library. It assumes that `awsenv` variables have been set.
+# It is copied almost verbatim from https://github.com/mitchellh/packer/issues/2756
+
+REGION=us-east-1
+
+aws ec2 describe-images \
+    --region $REGION \
+    --filter Name=owner-id,Values=099720109477 \
+    --query 'Images[? starts_with(ImageLocation, `099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server`)] | sort_by(@, & ImageLocation) | [-1] | ImageId'  --out text

--- a/scripts/get_latest_ami_helper.sh
+++ b/scripts/get_latest_ami_helper.sh
@@ -3,10 +3,13 @@
 # This script retrieves the latest official Canonical Ubuntu image from 
 # the AWS EC2 library. It assumes that `awsenv` variables have been set.
 # It is copied almost verbatim from https://github.com/mitchellh/packer/issues/2756
+# To look for images manually go to: https://cloud-images.ubuntu.com/locator/ec2
 
 REGION=us-east-1
+# Canonical's official owner ID: 099720109477
+OWNER_ID=099720109477
 
 aws ec2 describe-images \
     --region $REGION \
-    --filter Name=owner-id,Values=099720109477 \
+    --filter Name=owner-id,Values=$OWNER_ID \
     --query 'Images[? starts_with(ImageLocation, `099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server`)] | sort_by(@, & ImageLocation) | [-1] | ImageId'  --out text


### PR DESCRIPTION
This is just a minor enhancement to the `packer` work flow, saving us the need to use the browser and copy paste information when selecting AMIs.
