### PR TITLE
Added configuration options for openresty/nginx

### DIFF
--- a/ansible/roles/openresty/tasks/main.yml
+++ b/ansible/roles/openresty/tasks/main.yml
@@ -23,6 +23,9 @@
     - libncurses5-dev 
     - libpcre3-dev
     - libssl-dev 
+    - libgd2-dev
+    - libgeoip-dev
+    - libxslt-dev
     - perl 
     - make 
     - build-essential
@@ -42,7 +45,7 @@
   args:
     chdir: "/tmp/openresty/openresty-{{ openresty_version }}"
   with_items:
-    - ./configure
+    - ./configure --with-debug --with-pcre-jit --with-ipv6 --with-http_ssl_module --with-http_stub_status_module --with-http_realip_module --with-http_auth_request_module --with-http_addition_module --with-http_dav_module --with-http_geoip_module --with-http_gunzip_module --with-http_gzip_static_module  --with-http_image_filter_module --with-http_v2_module --with-http_sub_module --with-http_xslt_module --with-stream --with-stream_ssl_module --with-mail --with-mail_ssl_module --with-threads
     - make
     - make install
   when: openresty_exists_result.stdout != "1"


### PR DESCRIPTION
Flags were added for our OpenResty nginx package to reach parity
with vanilla Ubuntu nginx compiled version.
In addition supporting libraries required for compilation were
included in the apt packages part of the openresty tasks.
Tested on vagrant, nginx starts up as expected.