### PR TITLE
Phase 1 - enable 16.04 base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Builds Ubuntu AMIs using Ansible.
  4. Use our helper script to select the latest offical Ubuntu trusty AMI:
         
         export AWS_SOURCE_AMI=$(./scripts/get_latest_ami_helper.sh <version>)
-        _where version is one of *16.04* or *14.04*_
+
+    _where version is one of *16.04* or *14.04*_
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Builds Ubuntu AMIs using Ansible.
         
         export AWS_SOURCE_AMI=$(./scripts/get_latest_ami_helper.sh <version>)
 
-    _where version is one of *16.04* or *14.04*_
+    _Where `version` is either **`16.04`** or **`14.04`**_
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Builds Ubuntu AMIs using Ansible.
 
  4. Use our helper script to select the latest offical Ubuntu trusty AMI:
         
-        export AWS_SOURCE_AMI=$(./scripts/get_latest_ami_helper.sh)
+        export AWS_SOURCE_AMI=$(./scripts/get_latest_ami_helper.sh <version>)
+        _where version is one of *16.04* or *14.04*_
 
 ## Usage
 

--- a/aws/ebs.json
+++ b/aws/ebs.json
@@ -57,7 +57,7 @@
       "playbook_file": "ansible/packer.yml",
       "extra_arguments": [
         "-e aws_region={{user `aws_region`}}",
-	"--tags baseline"
+        "--tags baseline"
       ],
       "staging_directory": "{{user `ansible_staging_dir`}}"
     },
@@ -92,7 +92,7 @@
       "extra_arguments": [
         "-vvv",
         "-e aws_region={{user `aws_region`}}",
-	"--tags swapfile,codedeploy,cloudwatch,openresty,python,nodejs"
+        "--tags swapfile,codedeploy,cloudwatch,openresty,python,nodejs"
       ],
       "staging_directory": "{{user `ansible_staging_dir`}}"
     }

--- a/scripts/get_latest_ami_helper.sh
+++ b/scripts/get_latest_ami_helper.sh
@@ -9,7 +9,24 @@ REGION=us-east-1
 # Canonical's official owner ID: 099720109477
 OWNER_ID=099720109477
 
+usage(){
+    echo "USAGE: ./$0  [16.04|14.04]"
+    exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+	usage
+fi
+
+if [[ $1 == "16.04" ]]; then
+	UBUNTU_VERSION="xenial-16.04"
+elif [[ $1 == "14.04" ]]; then
+	UBUNTU_VERSION="trusty-14.04"
+else
+	usage
+fi
+
 aws ec2 describe-images \
     --region $REGION \
     --filter Name=owner-id,Values=$OWNER_ID \
-    --query "Images[? starts_with(ImageLocation, \`$OWNER_ID/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server\`)] | sort_by(@, & ImageLocation) | [-1] | ImageId"  --out text
+    --query "Images[? starts_with(ImageLocation, \`$OWNER_ID/ubuntu/images/hvm-ssd/ubuntu-$UBUNTU_VERSION-amd64-server\`)] | sort_by(@, & ImageLocation) | [-1] | ImageId"  --out text


### PR DESCRIPTION
Made our base image selection helper script interactive. We can now use 16.04.
That said, still won't _actually_ work without a ton of other work as defined in https://globality.atlassian.net/wiki/display/GLOB/New+Barebones+AMI.