### PR TITLE
Support 16.04 in Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Builds Ubuntu AMIs using Ansible.
 
 To test Ansible using Vagrant.
 
- 1. Bring up the vagrant instance.
+ 1. Choose an OS version, and bring up the vagrant instance.
 
-        vagrant up
+        vagrant up packer-ubuntu-<16.04|14.04>
 
  2. Change to the Ansible directory:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,16 @@
 nodes = [
-  { :hostname => "packer-ubuntu", :ip => "172.16.42.42", :box => "bento/ubuntu-14.04", :ram => "512", :cpus => 1},
+  { :hostname => "packer-ubuntu-14.04",
+    :ip => "172.16.42.42",
+    :box => "bento/ubuntu-14.04",
+    :ram => "512",
+    :cpus => 1
+  },
+  { :hostname => "packer-ubuntu-16.04",
+    :ip => "172.16.42.44",
+    :box => "bento/ubuntu-16.04",
+    :ram => "512",
+    :cpus => 1
+  }
 ]
 
 Vagrant.configure("2") do |config|
@@ -7,7 +18,7 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
   nodes.each do |node|
-    config.vm.define node[:hostname] do |node_config|
+    config.vm.define node[:hostname], autostart: false do |node_config|
       node_config.vm.box = node[:box]
       node_config.vm.hostname = node[:hostname]
       node_config.vm.network :private_network, ip: node[:ip]
@@ -15,6 +26,7 @@ Vagrant.configure("2") do |config|
         vb.memory = node[:ram]
         vb.cpus = node[:cpus]
         vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        vb.customize ["modifyvm", :id, "--audio", "none"]
         vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000]
       end
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,6 @@ Vagrant.configure("2") do |config|
         vb.memory = node[:ram]
         vb.cpus = node[:cpus]
         vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-        vb.customize ["modifyvm", :id, "--audio", "none"]
         vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000]
       end
     end


### PR DESCRIPTION
We can now bring up test machines for either 14.04 or 16.04.

This will accelerate the Ansible development process.