### PR TITLE
Install PostgreSQL PPA and specific postgresql-client version

### DIFF
--- a/packer.yml
+++ b/packer.yml
@@ -25,6 +25,8 @@
       tags: ["swapfile"]
     - role: codedeploy
       tags: ["aws", "codedeploy"]
+    - role: postgresql-client
+      tags: ["postgresql-client"]
   vars:
     aws_region: us-east-1
 

--- a/roles/postgresql-client/defaults/main.yml
+++ b/roles/postgresql-client/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+postgresql_client_version: 9.6

--- a/roles/postgresql-client/defaults/main.yml
+++ b/roles/postgresql-client/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 
-postgresql_client_version: 9.6
+postgresql_client_version: 9.5

--- a/roles/postgresql-client/tasks/main.yml
+++ b/roles/postgresql-client/tasks/main.yml
@@ -6,7 +6,7 @@
     content: |
       Package: postgresql-client
       Pin: release v={{ postgresql_client_version }}
-      Pin-Priority: 1002
+      Pin-Priority: 10
 
 - name: Install apt key for PostgreSQL PPA
   apt_key:
@@ -36,5 +36,5 @@
 
 - name: Install PostgreSQL client
   apt:
-    name: postgresql-client
+    name: postgresql-client-{{ postgresql_client_version }}
     state: latest

--- a/roles/postgresql-client/tasks/main.yml
+++ b/roles/postgresql-client/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+
+- name: Pin version of PostgreSQL client
+  copy:
+    dest: /etc/apt/preferences.d/fixed-postgresql-client
+    content: |
+      Package: postgresql-client
+      Pin: release v={{ postgresql_client_version }}
+      Pin-Priority: 1002
+
+- name: Install apt key for PostgreSQL PPA
+  apt_key:
+    url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+    state: present
+  when: ansible_lsb["codename"] == "xenial"
+
+# Ubunty Trusty's Python version (v2.7.6) doesn't support SNI so we have to resort to a shell command
+- name: Install workaround prerequisites
+  apt: 
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - httpie
+    - ca-certificates
+  when: ansible_lsb["codename"] == "trusty"
+
+- name: Install apt key for PostgreSQL PPA workaround Trusty bugs
+  shell: http GET https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+  when: ansible_lsb["codename"] == "trusty"
+
+- name: Configure PostgreSQL PPA
+  apt_repository:
+    repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_lsb['codename'] }}-pgdg main"
+    update_cache: yes
+    state: present
+
+- name: Install PostgreSQL client
+  apt:
+    name: postgresql-client
+    state: latest


### PR DESCRIPTION
We make use of `apt_preferences` for pinning the client version.

It is less than ideal for the Ansible role to differentiate tasks
based on OS versioning. The Trusty portions will be deprecated
eventually.