### PR TITLE
Add psycopg2 library to ECS enabled AMI

### DIFF
--- a/packer.yml
+++ b/packer.yml
@@ -26,11 +26,11 @@
     # Docker enabled ECS instances
     - role: ecs-agent
       tags: ["ecs"]
+    - role: python
+      tags: ["python"]
     # Legacy Web machines
     - role: openresty
       tags: ["openresty", "legacy"]
-    - role: python
-      tags: ["python", "legacy"]
     - role: nodejs
       tags: ["nodejs", "legacy"]
 

--- a/packer.yml
+++ b/packer.yml
@@ -27,10 +27,10 @@
     - role: ecs-agent
       tags: ["ecs"]
     # Legacy Web machines
-    - role: python
-      tags: ["python", "legacy"]
     - role: openresty
       tags: ["openresty", "legacy"]
+    - role: python
+      tags: ["python", "legacy"]
     - role: nodejs
       tags: ["nodejs", "legacy"]
 

--- a/packer.yml
+++ b/packer.yml
@@ -26,9 +26,9 @@
     # Docker enabled ECS instances
     - role: ecs-agent
       tags: ["ecs"]
-    - role: python
-      tags: ["python"]
     # Legacy Web machines
+    - role: python
+      tags: ["python", "legacy"]
     - role: openresty
       tags: ["openresty", "legacy"]
     - role: nodejs

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -16,3 +16,6 @@ sysctl_config:
   net.ipv4.tcp_fin_timeout: 15
   net.ipv4.tcp_window_scaling: 1
   net.ipv4.tcp_max_syn_backlog: 3240000
+
+pip_packages:
+  - psycopg2

--- a/roles/baseline/tasks/main.yml
+++ b/roles/baseline/tasks/main.yml
@@ -12,6 +12,12 @@
     state: present
   with_items: "{{ apt_packages }}"
 
+- name: install python libraries
+  pip:
+    name: "{{ item }}"
+    state: latest
+  with_items: "{{ pip_packages }}"
+
 - name: set timezone
   copy:
     content: "{{ timezone }}"


### PR DESCRIPTION
* Database operations rely on `psycopg2`