### PR TITLE
Remove unnecessary packages, temporarily disable intel network optimization

### DIFF
--- a/packer.yml
+++ b/packer.yml
@@ -12,8 +12,10 @@
   roles:
     - role: baseline
       tags: ["baseline"]
-    - role: intel-networking
-      tags: ["intel"]
+# See https://github.com/docker/docker.github.io/issues/2694
+# and https://github.com/angstwad/docker.ubuntu/issues/162
+#   - role: intel-networking
+#   - tags: ["intel"]
     - role: kamaln7.swapfile
       swapfile_size: 1GB
       swapfile_swappiness: 60

--- a/roles/docker-host/defaults/main.yml
+++ b/roles/docker-host/defaults/main.yml
@@ -2,7 +2,6 @@
 packages:
   - python-docker
   - curl
-  - "linux-image-extra-{{ ansible_kernel }}"
   - linux-image-extra-virtual
   - apt-transport-https
   - ca-certificates

--- a/roles/intel-networking/tasks/main.yml
+++ b/roles/intel-networking/tasks/main.yml
@@ -9,7 +9,8 @@
   with_items:
     - tar
     - dkms
-    - linux-headers-{{ ansible_kernel }}
+    - linux-aws
+    - linux-headers-aws
 
 - name: Download Intel driver source
   command: >


### PR DESCRIPTION
* The `linux-image-extra` package is unnecessary for the installation of the
Docker engine
* The Intel network card module (`ixgbevf`) depends on headers that aren't yet
included in the Canonical AMI in order to compile
* When the package is available we can uncomment the lines