### PR TITLE
Lookup AWS region from environment

### DIFF
--- a/packer.yml
+++ b/packer.yml
@@ -27,4 +27,4 @@
       tags: ["ecs"]
 
   vars:
-    aws_region: us-east-1
+    aws_region: "{{ lookup('env', 'AWS_DEFAULT_REGION') }}"


### PR DESCRIPTION
This makes it easier to move between regions when building images.